### PR TITLE
Updates to 3.11.174 with GitHub action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,14 +35,13 @@ jobs:
           cd ..
       - name: Install pdfjs-dist-viewer-min dependencies
         run: npm install
-      - name: Build pdf.js generic
+      - name: Build pdf.js minified
         run: |
-          npx gulp --cwd pdf.js generic
-          npx gulp --cwd pdf.js image_decoders
+          npx gulp --cwd pdf.js minified
       - name: Deploy into build/minified
         run: |
-          rsync -rtlDPvc --delete pdf.js/build/generic/ build/minified/
-          rsync -rtlDPvc --delete pdf.js/build/default_preferences/generic/ build/default_preferences/minified/web/
+          rsync -rtlDPvc --delete pdf.js/build/minified/ build/minified/
+          rsync -rtlDPvc --delete pdf.js/build/default_preferences/minified/ build/default_preferences/minified/web/
           rsync -rtlDPvc pdf.js/build/image_decoders build/minified/
       - name: Git Status
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,5 +52,5 @@ jobs:
           git add -A
           git commit -m "Build of ${{ env.PDFJS_VERSION }}"
           git tag ${{ env.PDFJS_VERSION }}
-          git push origin main --tags
+          git push origin ${{ env.PDFJS_VERSION }} -f
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,6 @@ jobs:
         run: |
           rsync -rtlDPvc --delete pdf.js/build/minified/ build/minified/
           rsync -rtlDPvc --delete pdf.js/build/default_preferences/minified/ build/default_preferences/minified/web/
-          rsync -rtlDPvc pdf.js/build/image_decoders build/minified/
       - name: Git Status
         run: |
           git status --porcelain

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,15 +42,14 @@ jobs:
         run: |
           rsync -rtlDPvc --delete pdf.js/build/minified/ build/minified/
           rsync -rtlDPvc --delete pdf.js/build/default_preferences/minified/ build/default_preferences/minified/web/
-      - name: Git Status
+      - name: Commit and tag if there are changes
         run: |
-          git status --porcelain
-      - name: Commit new build
-        run: |
-          git config user.name 'github-actions'
-          git config user.email 'github-actions@users.noreply.github.com'
-          git add -A
-          git commit -m "Build of ${{ env.PDFJS_VERSION }}"
-          git tag ${{ env.PDFJS_VERSION }}
-          git push origin ${{ env.PDFJS_VERSION }} -f
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name 'github-actions'
+            git config user.email 'github-actions@users.noreply.github.com'
+            git add -A
+            git commit -m "Build of ${{ env.PDFJS_VERSION }}"
+            git tag ${{ env.PDFJS_VERSION }}
+            git push origin ${{ env.PDFJS_VERSION }} -f
+          fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+name: "build pdfjs"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Installs jq
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install jq
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+      - name: Get package.json version
+        run: |
+          echo "PDFJS_VERSION=v$(jq .version package.json | sed 's#\": ##g')" >> $GITHUB_ENV
+      - name: Get latest pdf.js source
+        run: |
+          git clone --depth 5 --branch ${{ env.PDFJS_VERSION }} https://github.com/mozilla/pdf.js.git
+      - name: Install pdf.js dependencies
+        run: |
+          cd pdf.js
+          npm install
+          cd ..
+      - name: Install pdfjs-dist-viewer-min dependencies
+        run: npm install
+      - name: Build pdf.js generic
+        run: |
+          npx gulp --cwd pdf.js generic
+          npx gulp --cwd pdf.js image_decoders
+      - name: Deploy into build/minified
+        run: |
+          rsync -rtlDPvc --delete pdf.js/build/generic/ build/minified/
+          rsync -rtlDPvc --delete pdf.js/build/default_preferences/generic/ build/default_preferences/minified/web/
+          rsync -rtlDPvc pdf.js/build/image_decoders build/minified/
+      - name: Git Status
+        run: |
+          git status --porcelain
+      - name: Commit new build
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@users.noreply.github.com'
+          git add -A
+          git commit -m "Build of v${{ env.PDFJS_VERSION }}"
+          git tag v${{ env.PDFJS_VERSION }}
+          git push --tags
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           git config user.name 'github-actions'
           git config user.email 'github-actions@users.noreply.github.com'
           git add -A
-          git commit -m "Build of v${{ env.PDFJS_VERSION }}"
-          git tag v${{ env.PDFJS_VERSION }}
-          git push --tags
+          git commit -m "Build of ${{ env.PDFJS_VERSION }}"
+          git tag ${{ env.PDFJS_VERSION }}
+          git push origin main --tags
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+pdf.js/

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.12.313",
-  "build": 313,
-  "commit": "a2ae56f39"
+  "version": "3.11.174",
+  "build": 174,
+  "commit": "ce87167"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfjs-dist-viewer-min",
-  "version": "2.12.313",
+  "version": "3.11.174",
   "description": "Generic minified build of Mozilla's PDF.js library including the viewer component.",
   "repository": {
     "type": "git",
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/mozilla/pdf.js/issues"
   },
-  "homepage": "http://mozilla.github.io/pdf.js/"
+  "homepage": "http://mozilla.github.io/pdf.js/",
+  "devDependencies": {
+    "gulp": "^5.0.0"
+  }
 }


### PR DESCRIPTION
- Adds GitHub action to build pdfjs-dist-viewer-min from pdf.js and optionally tag a release
- Updates to v3.11.174
- Adds gulp as a dev dependency.

If merged into main, this will build and tag a new release on GitHub for 3.11.174.

Squash merging this would probably be preferable than a regular merge.